### PR TITLE
Added license information

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+# Contributors
+
+- [mariobadr](https://github.com/mariobadr)
+- [Chris Hutchinson](https://github.com/chutchinson)
+- [Joshua Michael Daly](https://github.com/swordmaster2k)
+- [goblinJoel](https://github.com/goblinJoel)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+# License
+
+Mozilla Public License 2.0
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. If a copy of the MPL was not distributed with this file,
+you can obtain one at http://mozilla.org/MPL/2.0/.

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
@@ -14,33 +23,6 @@
     
     <artifactId>common</artifactId>
     <packaging>jar</packaging>
-    
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+   
+        
 </project>

--- a/common/src/main/java/net/rpgtoolkit/common/CorruptAssetException.java
+++ b/common/src/main/java/net/rpgtoolkit/common/CorruptAssetException.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common;
 
 public class CorruptAssetException extends Throwable

--- a/common/src/main/java/net/rpgtoolkit/common/Selectable.java
+++ b/common/src/main/java/net/rpgtoolkit/common/Selectable.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common;
 
 /**

--- a/common/src/main/java/net/rpgtoolkit/common/assets/AbstractAssetSerializer.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/AbstractAssetSerializer.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/AnimatedTile.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/AnimatedTile.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import net.rpgtoolkit.common.CorruptAssetException;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Animation.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Animation.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.io.*;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/AnimationFrame.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/AnimationFrame.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 //import uk.co.tkce.engine.Texture;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Asset.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Asset.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 /// See LICENSE.md in the distribution for the full license text including,
 /// but not limited to, a notice of warranty and distribution rights.
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/AssetDescriptor.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/AssetDescriptor.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/AssetHandle.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/AssetHandle.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 /*
  * See LICENSE.md in the distribution for the full license text including,
  * but not limited to, a notice of warranty and distribution rights.

--- a/common/src/main/java/net/rpgtoolkit/common/assets/AssetHandleResolver.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/AssetHandleResolver.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/AssetManager.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/AssetManager.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/AssetSerializer.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/AssetSerializer.java
@@ -1,6 +1,10 @@
-/// See LICENSE.md in the distribution for the full license text including,
-/// but not limited to, a notice of warranty and distribution rights.
-
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.io.IOException;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Background.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Background.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.io.File;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BasicType.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BasicType.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.io.File;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Board.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Board.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.*;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardChangeListener.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardChangeListener.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.util.EventListener;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardChangedEvent.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardChangedEvent.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.util.EventObject;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardImage.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardImage.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.image.BufferedImage;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardLayer.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardLayer.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.Point;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardLayerShade.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardLayerShade.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.*;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardLight.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardLight.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.Color;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardProgram.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardProgram.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 public class BoardProgram extends BasicType implements Cloneable

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardSprite.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardSprite.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.image.BufferedImage;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/BoardVector.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/BoardVector.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.Point;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Enemy.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Enemy.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import net.rpgtoolkit.common.CorruptAssetException;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/EnemySkillPair.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/EnemySkillPair.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 /**

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Item.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Item.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.util.ArrayList;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/ItemWalkDirection.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/ItemWalkDirection.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Player.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Player.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.*;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/PlayerSpecialMove.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/PlayerSpecialMove.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 /**

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Program.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Program.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.io.File;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Project.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Project.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import net.rpgtoolkit.common.CorruptAssetException;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/RunTimeKey.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/RunTimeKey.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 /**

--- a/common/src/main/java/net/rpgtoolkit/common/assets/SpecialMove.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/SpecialMove.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import net.rpgtoolkit.common.CorruptAssetException;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/StatusEffect.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/StatusEffect.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import net.rpgtoolkit.common.CorruptAssetException;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/Tile.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/Tile.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.*;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/TilePixelOutOfRangeException.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/TilePixelOutOfRangeException.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 public class TilePixelOutOfRangeException extends Throwable

--- a/common/src/main/java/net/rpgtoolkit/common/assets/TileSet.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/TileSet.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.assets;
 
 import java.awt.*;

--- a/common/src/main/java/net/rpgtoolkit/common/assets/files/FileAssetHandle.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/files/FileAssetHandle.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets.files;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/files/FileAssetHandleResolver.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/files/FileAssetHandleResolver.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets.files;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/resources/ResourceAssetHandle.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/resources/ResourceAssetHandle.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets.resources;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/resources/ResourceAssetHandleResolver.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/resources/ResourceAssetHandleResolver.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets.resources;
 

--- a/common/src/main/java/net/rpgtoolkit/common/assets/serialization/LegacyItemSerializer.java
+++ b/common/src/main/java/net/rpgtoolkit/common/assets/serialization/LegacyItemSerializer.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.assets.serialization;
 

--- a/common/src/main/java/net/rpgtoolkit/common/io/BinaryReader.java
+++ b/common/src/main/java/net/rpgtoolkit/common/io/BinaryReader.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.io;
 
 import java.io.EOFException;

--- a/common/src/main/java/net/rpgtoolkit/common/io/Paths.java
+++ b/common/src/main/java/net/rpgtoolkit/common/io/Paths.java
@@ -1,6 +1,9 @@
-/*
- * See LICENSE.md in the distribution for the full license text including,
- * but not limited to, a notice of warranty and distribution rights.
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package net.rpgtoolkit.common.io;
 

--- a/common/src/main/java/net/rpgtoolkit/common/utilities/BinaryIO.java
+++ b/common/src/main/java/net/rpgtoolkit/common/utilities/BinaryIO.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.utilities;
 
 import java.io.FileInputStream;

--- a/common/src/main/java/net/rpgtoolkit/common/utilities/DOSColors.java
+++ b/common/src/main/java/net/rpgtoolkit/common/utilities/DOSColors.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.utilities;
 
 import java.awt.*;

--- a/common/src/main/java/net/rpgtoolkit/common/utilities/TileSetCache.java
+++ b/common/src/main/java/net/rpgtoolkit/common/utilities/TileSetCache.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.utilities;
 
 import java.io.File;

--- a/common/src/test/java/net/rpgtoolkit/common/io/BinaryReaderTests.java
+++ b/common/src/test/java/net/rpgtoolkit/common/io/BinaryReaderTests.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.common.io;
 
 import java.io.IOException;

--- a/common/src/test/java/net/rpgtoolkit/common/io/LegacyAssetSerializerTests.java
+++ b/common/src/test/java/net/rpgtoolkit/common/io/LegacyAssetSerializerTests.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 /*
  * See LICENSE.md in the distribution for the full license text including,
  * but not limited to, a notice of warranty and distribution rights.

--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
@@ -17,31 +26,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/editor/src/main/java/net/rpgtoolkit/editor/Driver.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/Driver.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor;
 
 import javax.swing.*;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/AbstractBoardView.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/AbstractBoardView.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import java.awt.Color;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/AnimationEditor.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/AnimationEditor.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import java.awt.*;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/BoardEditor.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/BoardEditor.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import net.rpgtoolkit.editor.editors.board.BoardView2D;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/CharacterEditor.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/CharacterEditor.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import net.rpgtoolkit.common.assets.Player;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/EnemyEditor.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/EnemyEditor.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/LayerChangeListener.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/LayerChangeListener.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/LayerChangedEvent.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/LayerChangedEvent.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/ProjectEditor.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/ProjectEditor.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import javax.swing.*;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/SpecialMoveEditor.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/SpecialMoveEditor.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/TileCanvas.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/TileCanvas.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import java.awt.*;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/TileEditor.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/TileEditor.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import java.awt.*;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/TileRegionSelectionEvent.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/TileRegionSelectionEvent.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/TileSelectionEvent.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/TileSelectionEvent.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/TileSelectionListener.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/TileSelectionListener.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/TilesetCanvas.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/TilesetCanvas.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors;
 
 import java.awt.AlphaComposite;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/AbstractBrush.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/AbstractBrush.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Dimension;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BoardLayerView.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BoardLayerView.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.AlphaComposite;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BoardLayersTableModel.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BoardLayersTableModel.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import javax.swing.table.AbstractTableModel;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BoardMouseAdapter.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BoardMouseAdapter.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Point;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BoardView2D.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BoardView2D.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.AlphaComposite;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/Brush.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/Brush.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Dimension;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BucketBrush.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/BucketBrush.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Graphics2D;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/CustomBrush.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/CustomBrush.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Graphics2D;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/MultiLayerContainer.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/MultiLayerContainer.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Rectangle;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/SelectionBrush.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/SelectionBrush.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Rectangle;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/ShapeBrush.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/ShapeBrush.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Dimension;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/SpriteBrush.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/SpriteBrush.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Graphics2D;

--- a/editor/src/main/java/net/rpgtoolkit/editor/editors/board/VectorBrush.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/editors/board/VectorBrush.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.editors.board;
 
 import java.awt.Graphics2D;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/AbstractModelPanel.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/AbstractModelPanel.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.GridLayout;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/BoardSpritePanel.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/BoardSpritePanel.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.FlowLayout;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/BoardVectorPanel.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/BoardVectorPanel.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/EditMenu.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/EditMenu.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/EditorButton.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/EditorButton.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 /*
  * See LICENSE.md in the distribution for the full license text including,
  * but not limited to, a notice of warranty and distribution rights.

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/FileMenu.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/FileMenu.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/Gui.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/Gui.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/HelpMenu.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/HelpMenu.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.KeyEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/IntegerField.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/IntegerField.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.text.NumberFormat;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/LayerPanel.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/LayerPanel.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.Dimension;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/MainMenuBar.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/MainMenuBar.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import javax.swing.*;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/MainToolBar.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/MainToolBar.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.Rectangle;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/MainWindow.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/MainWindow.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.*;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ModelPanelFactory.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ModelPanelFactory.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import net.rpgtoolkit.common.assets.Board;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ProjectMenu.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ProjectMenu.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.KeyEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ProjectPanel.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ProjectPanel.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import javax.swing.JPanel;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/PropertiesPanel.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/PropertiesPanel.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.BorderLayout;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/RunMenu.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/RunMenu.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.KeyEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ShowCoordinatesItemListener.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ShowCoordinatesItemListener.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.ItemEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ShowGridItemListener.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ShowGridItemListener.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.ItemEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ShowVectorsItemListener.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ShowVectorsItemListener.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.ItemEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/TileSetPanel.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/TileSetPanel.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.BorderLayout;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ToolkitDesktopManager.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ToolkitDesktopManager.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import javax.swing.DefaultDesktopManager;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ToolkitEditorWindow.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ToolkitEditorWindow.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import javax.swing.JInternalFrame;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ToolsMenu.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ToolsMenu.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.KeyEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/ViewMenu.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/ViewMenu.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/WholeNumberField.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/WholeNumberField.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui;
 
 import java.text.NumberFormat;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/actions/ShowGridAction.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/actions/ShowGridAction.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui.actions;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/actions/ZoomInAction.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/actions/ZoomInAction.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui.actions;
 
 import java.awt.event.ActionEvent;

--- a/editor/src/main/java/net/rpgtoolkit/editor/ui/actions/ZoomOutAction.java
+++ b/editor/src/main/java/net/rpgtoolkit/editor/ui/actions/ZoomOutAction.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package net.rpgtoolkit.editor.ui.actions;
 
 import java.awt.event.ActionEvent;

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2015, rpgtoolkit.net <help@rpgtoolkit.net>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
@@ -10,10 +19,61 @@
     <artifactId>rpgtoolkit</artifactId>
     <version>4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+    <inceptionYear>2015</inceptionYear>
+        
     <modules>
         <module>common</module>
         <module>editor</module>
     </modules>
     
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <version>2.11</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.11</version>
+                <configuration>
+                    <header>com/mycila/maven/plugin/license/templates/MPL-2.txt</header>
+                    <properties>
+                        <owner>rpgtoolkit.net</owner>
+                        <email>help@rpgtoolkit.net</email>
+                    </properties>
+                    <excludes>
+                        <exclude>src/main/resources/**</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,22 @@
     <version>4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <inceptionYear>2015</inceptionYear>
+    
+    <developers>
+        <developer>
+            <id>chutchinson</id>
+            <name>Chris Hutchinson</name>
+            <timezone>America/Detroit</timezone>
+        </developer>
+    </developers>
+    
+    <repositories>
+        <repository>
+            <id>remote</id>
+            <name>GitHub</name>
+            <url>https://github.com/rpgtoolkit</url>
+        </repository>
+    </repositories>
         
     <modules>
         <module>common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20141113</version>
+        </dependency>
+        <dependency>
             <groupId>com.mycila</groupId>
             <artifactId>license-maven-plugin</artifactId>
             <version>2.11</version>


### PR DESCRIPTION
Added MPL 2 as the governing license for the project. MPL 2 is a BSD license that allows for almost complete freedom while still requiring attribution and source code distribution. The license is supported, defended, and written by the Mozilla Organization. The license has held up to legal scrutiny and the legal language is verbose and complete. The MPL 2 is essentially a mix between liberal (BSD, ISC, MIT) and copyleft licenses (LGPL).

A license plugin was added to the build system to make license header formatting painless. In the future this plugin may be added as part of the build process. Meaniwhile, you can invoke copyright boilerplate processing with these maven goals:
- license:check
- license:format
- license:remove
